### PR TITLE
fix: :bug: (#76) issue with quotes in commit msg title

### DIFF
--- a/pkg/commit.go
+++ b/pkg/commit.go
@@ -165,7 +165,7 @@ func ExecuteCommit(title string, body string, config Config) {
 func BuildCommitTitle(_type string, scope string, isBreaking bool, desc string, gitmoji Gitmoji, config Config) string {
 
 	var s strings.Builder
-	s.WriteString("\"")
+	//s.WriteString("\"")
 	s.WriteString(_type)
 
 	if scope != "" {
@@ -178,7 +178,7 @@ func BuildCommitTitle(_type string, scope string, isBreaking bool, desc string, 
 
 	s.WriteString(fmt.Sprintf(": %s ", gitmojiToString(gitmoji, config)))
 	s.WriteString(eventualCapitalizeTitle(desc, config))
-	s.WriteString("\"")
+	//s.WriteString("\"")
 	return s.String()
 }
 

--- a/pkg/commit_test.go
+++ b/pkg/commit_test.go
@@ -45,7 +45,7 @@ func TestBuildCommitTitleCodeFormatIsNotBreakingNoScopeEqualsExp(t *testing.T) {
 	desc := "test description"
 	config := buildCommitTestConfig(pkg.CODE)
 	title := pkg.BuildCommitTitle(_type, scope, isBreaking, desc, gitmoji, config)
-	exp := "\"feat: :beers: test description\""
+	exp := "feat: :beers: test description"
 	assert.Equal(t, exp, title)
 }
 
@@ -56,7 +56,7 @@ func TestBuildCommitTitleEmojiFormatIsNotBreakingNoScopeEqualsExp(t *testing.T) 
 	desc := "test description"
 	config := buildCommitTestConfig(pkg.EMOJI)
 	title := pkg.BuildCommitTitle(_type, scope, isBreaking, desc, gitmoji, config)
-	exp := fmt.Sprintf("\"feat: %s test description\"", "🍻")
+	exp := fmt.Sprintf("feat: %s test description", "🍻")
 	assert.Equal(t, exp, title)
 }
 
@@ -67,7 +67,7 @@ func TestBuildCommitTitleCodeFormatIsNotBreakingWithScopeEqualsExp(t *testing.T)
 	desc := "test description"
 	config := buildCommitTestConfig(pkg.CODE)
 	title := pkg.BuildCommitTitle(_type, scope, isBreaking, desc, gitmoji, config)
-	exp := fmt.Sprintf("\"feat(test): %s test description\"", ":beers:")
+	exp := fmt.Sprintf("feat(test): %s test description", ":beers:")
 	assert.Equal(t, exp, title)
 }
 
@@ -78,7 +78,7 @@ func TestBuildCommitTitleEmojiFormatIsNotBreakingWithScopeEqualsExp(t *testing.T
 	desc := "test description"
 	config := buildCommitTestConfig(pkg.EMOJI)
 	title := pkg.BuildCommitTitle(_type, scope, isBreaking, desc, gitmoji, config)
-	exp := fmt.Sprintf("\"feat(test): %s test description\"", "🍻")
+	exp := fmt.Sprintf("feat(test): %s test description", "🍻")
 	assert.Equal(t, exp, title)
 }
 
@@ -89,7 +89,7 @@ func TestBuildCommitTitleCodeFormatIsBreakingWithScopeEqualsExp(t *testing.T) {
 	desc := "test description"
 	config := buildCommitTestConfig(pkg.CODE)
 	title := pkg.BuildCommitTitle(_type, scope, isBreaking, desc, gitmoji, config)
-	exp := fmt.Sprintf("\"feat(test)!: %s test description\"", ":beers:")
+	exp := fmt.Sprintf("feat(test)!: %s test description", ":beers:")
 	assert.Equal(t, exp, title)
 }
 
@@ -100,7 +100,7 @@ func TestBuildCommitTitleEmojiFormatIsBreakingWithScopeEqualsExp(t *testing.T) {
 	desc := "test description"
 	config := buildCommitTestConfig(pkg.EMOJI)
 	title := pkg.BuildCommitTitle(_type, scope, isBreaking, desc, gitmoji, config)
-	exp := fmt.Sprintf("\"feat(test)!: %s test description\"", "🍻")
+	exp := fmt.Sprintf("feat(test)!: %s test description", "🍻")
 	assert.Equal(t, exp, title)
 }
 


### PR DESCRIPTION
# Description

Close #76 

fix issue with quotes in commit msg title

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
