### PR TITLE
feat(#137): :sparkles: possible to add a commit signature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-- package-ecosystem: gomod
+- package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: weekly
-- package-ecosystem: docker
+    interval: "weekly"
+- package-ecosystem: "docker"
   directory: "/"
   schedule:
-    interval: weekly
+    interval: "weekly"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/workflows/release_go.yml
+++ b/.github/workflows/release_go.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
-          version: latest
+          version: '~> v1'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -22,8 +22,7 @@ jobs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release-please
         with:
           release-type: go
-          prerelease: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -164,7 +164,7 @@ brews:
       zsh_completion.install "completions/{{ .ProjectName }}.zsh" => "_{{ .ProjectName }}"
       fish_completion.install "completions/{{ .ProjectName }}.fish"
       man1.install "manpages/{{ .ProjectName }}.1.gz"
-    folder: Formula
+    directory: Formula
     license: "MIT"
     skip_upload: false
 

--- a/README.md
+++ b/README.md
@@ -103,17 +103,18 @@ or with command line flags.
 Environment variables are supported (case insensitive). The key is the same like the parameter with a prefix **GO_GITMOJI_CLI_**.
 All parameters are able to be modified with flags.
 
-| **parameter**            | **description**                                                                                 | **default**                        |
-|--------------------------|-------------------------------------------------------------------------------------------------|------------------------------------|
-| auto_add                 | perform automatically a `git add .`                                                             | `false`                            |
+| **parameter**            | **description**                                                                              | **default**                        |
+|--------------------------|----------------------------------------------------------------------------------------------|------------------------------------|
+| auto_add                 | perform automatically a `git add .`                                                          | `false`                            |
 | auto_sign                | automatically sign commits (can also be configured with git `git config -g commit.gpgsign=true` | `false`                            |
-| emoji_format             | format of emojis `code/emoji`                                                                   | `code`                             |
-| scope_prompt             | Prompt for adding the commit scope                                                              | `false`                            |
-| body_prompt              | Prompt for adding the commit message body                                                       | `false`                            |
-| capitalize_title         | If set to true the commit title description will be capitalized                                 | `false`                            |
-| gitmojis_url             | The URL of the gitmojis database                                                                | `https://gitmoji.dev/api/gitmojis` |
-| use_default_git_messages | Use the default git messages (merge, squash, ammend,..)                                         | `true`                             |
-| debug                    | enable debug mode                                                                               | `false`                            |
+| auto_signature | automatically add signature to commits                                                       | `true`                              |
+| emoji_format             | format of emojis `code/emoji`                                                                | `code`                             |
+| scope_prompt             | Prompt for adding the commit scope                                                           | `false`                            |
+| body_prompt              | Prompt for adding the commit message body                                                    | `false`                            |
+| capitalize_title         | If set to true the commit title description will be capitalized                              | `false`                            |
+| gitmojis_url             | The URL of the gitmojis database                                                             | `https://gitmoji.dev/api/gitmojis` |
+| use_default_git_messages | Use the default git messages (merge, squash, ammend,..)                                      | `true`                             |
+| debug                    | enable debug mode                                                                            | `false`                            |
 
 The configuration values can be changed with
 

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -74,6 +74,7 @@ func init() {
 
 	bindAndAddBoolFlagP(CommitCmd, string(pkg.AUTO_ADD), "auto-add", "a", "call git add . before commit")
 	bindAndAddBoolFlagP(CommitCmd, string(pkg.AUTO_SIGN), "auto-sign", "S", "add -S flag to git commit")
+	bindAndAddBoolFlagP(CommitCmd, string(pkg.AUTO_SIGNATURE), "auto-signature", "s", "add -s flag to add signature to git commit")
 	bindAndAddBoolFlag(CommitCmd, string(pkg.CAPITALIZE_TITLE), "capitalize-title", "capitalize the title")
 	bindAndAddBoolFlag(CommitCmd, string(pkg.SCOPE_PROMPT), "scope-prompt", "enable scope prompt")
 	bindAndAddBoolFlag(CommitCmd, string(pkg.BODY_PROMPT), "body-prompt", "enable body prompt")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,6 +24,7 @@ var ConfigCmd = &cobra.Command{
 		}
 		autoAdd := runConfigConfirmationPrompt("Enable automatic 'git add .'", config.AutoAdd)
 		autoSign := runConfigConfirmationPrompt("Automatically sign commits (add '-S' flag)", config.AutoSign)
+		autoSignature := runConfigConfirmationPrompt("Automatically add signature to commits (add '-s' flag)", config.AutoSignature)
 		emojiFormat := runEmojiSelectionPrompt("Select how emojis should be used in commits. For a comparison please visit https://gitmoji.dev/specification")
 		scopePrompt := runConfigConfirmationPrompt("Enable scope prompt", config.ScopePrompt)
 		bodyPrompt := runConfigConfirmationPrompt("Enable body prompt", config.BodyPrompt)
@@ -34,6 +35,7 @@ var ConfigCmd = &cobra.Command{
 		config = pkg.Config{
 			AutoAdd:               autoAdd,
 			AutoSign:              autoSign,
+			AutoSignature:         autoSignature,
 			EmojiFormat:           emojiFormat,
 			ScopePrompt:           scopePrompt,
 			CapitalizeTitle:       capitalizeTitle,

--- a/pkg/commit.go
+++ b/pkg/commit.go
@@ -154,7 +154,7 @@ func CreateMessage(inputsRes []TextInputRes, selectedGitmoji Gitmoji, initialCom
 }
 
 func ExecuteCommit(title string, body string, config Config) {
-	commitCmd, err := utils.BuildGitCommitCommandStr(config.AutoAdd, config.AutoSign, title, body)
+	commitCmd, err := utils.BuildGitCommitCommandStr(config.AutoAdd, config.AutoSign, config.AutoSignature, title, body)
 	if err != nil {
 		log.Fatalf("error building commit message: %s", err)
 	}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -49,6 +49,7 @@ func LoadConfig(configPaths []string) (err error) {
 	log.Debug("Load config")
 	viper.SetDefault(string(AUTO_ADD), false)
 	viper.SetDefault(string(AUTO_SIGN), false)
+	viper.SetDefault(string(AUTO_SIGNATURE), true)
 	viper.SetDefault(string(EMOJI_FORMAT), string(CODE))
 	viper.SetDefault(string(SCOPE_PROMPT), false)
 	viper.SetDefault(string(BODY_PROMPT), false)
@@ -93,6 +94,7 @@ func GetCurrentConfig() (config Config, err error) {
 func UpdateConfig(config Config, isGlobalConfig bool) {
 	viper.Set(string(AUTO_ADD), config.AutoAdd)
 	viper.Set(string(AUTO_SIGN), config.AutoSign)
+	viper.Set(string(AUTO_SIGNATURE), config.AutoSignature)
 	viper.Set(string(EMOJI_FORMAT), string(config.EmojiFormat))
 	viper.Set(string(SCOPE_PROMPT), config.ScopePrompt)
 	viper.Set(string(BODY_PROMPT), config.BodyPrompt)

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -35,6 +35,7 @@ func TestConfigDefaultValuesEqualsExpected(t *testing.T) {
 	expected := pkg.Config{
 		EmojiFormat:           pkg.CODE,
 		AutoAdd:               false,
+		AutoSignature:         true,
 		ScopePrompt:           false,
 		BodyPrompt:            false,
 		CapitalizeTitle:       false,
@@ -46,6 +47,7 @@ func TestConfigDefaultValuesEqualsExpected(t *testing.T) {
 
 func TestConfigEnvVariablesEqualsExpected(t *testing.T) {
 	var autoadd = true
+	var autoSignature = true
 	var emojiFormat = pkg.EMOJI
 	var scopePrompt = true
 	var bodyPrompt = true
@@ -62,6 +64,7 @@ func TestConfigEnvVariablesEqualsExpected(t *testing.T) {
 	}()
 
 	t.Setenv(addEnvPrefix(string(pkg.AUTO_ADD)), strconv.FormatBool(autoadd))
+	t.Setenv(addEnvPrefix(string(pkg.AUTO_SIGNATURE)), strconv.FormatBool(autoSignature))
 	t.Setenv(addEnvPrefix(string(pkg.EMOJI_FORMAT)), string(emojiFormat))
 	t.Setenv(addEnvPrefix(string(pkg.SCOPE_PROMPT)), strconv.FormatBool(scopePrompt))
 	t.Setenv(addEnvPrefix(string(pkg.BODY_PROMPT)), strconv.FormatBool(bodyPrompt))
@@ -78,6 +81,7 @@ func TestConfigEnvVariablesEqualsExpected(t *testing.T) {
 		EmojiFormat:           emojiFormat,
 		AutoAdd:               autoadd,
 		AutoSign:              autoSign,
+		AutoSignature:         autoSignature,
 		ScopePrompt:           scopePrompt,
 		BodyPrompt:            bodyPrompt,
 		CapitalizeTitle:       capitalizeTitle,
@@ -102,6 +106,7 @@ func TestConfigConfigFileEqualsExpected(t *testing.T) {
 	expected := pkg.Config{
 		EmojiFormat:           pkg.EMOJI,
 		AutoAdd:               true,
+		AutoSignature:         true,
 		ScopePrompt:           true,
 		BodyPrompt:            true,
 		CapitalizeTitle:       true,

--- a/pkg/models.go
+++ b/pkg/models.go
@@ -47,6 +47,7 @@ type ConfigEnum string
 const (
 	AUTO_ADD                 ConfigEnum = "AUTO_ADD"
 	AUTO_SIGN                ConfigEnum = "AUTO_SIGN"
+	AUTO_SIGNATURE           ConfigEnum = "AUTO_SIGNATURE"
 	EMOJI_FORMAT             ConfigEnum = "EMOJI_FORMAT"
 	SCOPE_PROMPT             ConfigEnum = "SCOPE_PROMPT"
 	GITMOJIS_URL             ConfigEnum = "GITMOJIS_URL"
@@ -88,6 +89,7 @@ func (i EmojiCommitFormats) Description() string {
 type Config struct {
 	AutoAdd               bool               `mapstructure:"AUTO_ADD" json:"auto_add"`
 	AutoSign              bool               `mapstructure:"AUTO_SIGN" json:"auto_sign"`
+	AutoSignature         bool               `mapstructure:"AUTO_SIGNATURE" json:"auto_signature"`
 	EmojiFormat           EmojiCommitFormats `mapstructure:"EMOJI_FORMAT" json:"emoji_format"`
 	ScopePrompt           bool               `mapstructure:"SCOPE_PROMPT" json:"scope_prompt"`
 	BodyPrompt            bool               `mapstructure:"BODY_PROMPT" json:"body_prompt"`

--- a/pkg/test_data/.gitmojirc.json
+++ b/pkg/test_data/.gitmojirc.json
@@ -1,6 +1,7 @@
 {
   "auto_add": true,
   "auto_sign": false,
+  "auto_signature": true,
   "body_prompt": true,
   "capitalize_title": true,
   "debug": true,

--- a/pkg/utils/git.go
+++ b/pkg/utils/git.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"strings"
 )
@@ -47,11 +48,14 @@ func Commit(commitCommand string) {
 	log.Infof("commit done: %s", resultOutput)
 }
 
-func BuildGitCommitCommandStr(isAutoAdd bool, isSignCommit bool, title string, body string) (string, error) {
+func BuildGitCommitCommandStr(isAutoAdd bool, isSignCommit bool, isCommitSignature bool, title string, body string) (string, error) {
 	var str strings.Builder
 	str.WriteString("git commit ")
 	if isAutoAdd {
 		str.WriteString("-a ")
+	}
+	if isCommitSignature {
+		str.WriteString("-s ")
 	}
 	if isSignCommit {
 		str.WriteString("-S ")
@@ -60,11 +64,11 @@ func BuildGitCommitCommandStr(isAutoAdd bool, isSignCommit bool, title string, b
 		return "", errors.New("the title must not be empty")
 	}
 	str.WriteString("-m ")
-	str.WriteString(title)
+	str.WriteString(fmt.Sprintf("'%s'", title))
 	str.WriteString(" ")
 	if body != "" {
 		str.WriteString("-m ")
-		str.WriteString(body)
+		str.WriteString(fmt.Sprintf("'%s'", body))
 	}
 	return str.String(), nil
 }

--- a/pkg/utils/git_test.go
+++ b/pkg/utils/git_test.go
@@ -93,35 +93,35 @@ func TestGetHooksDirectoryUsesCorrectCommand(t *testing.T) {
 func TestBuildGitCommitCommandStrNoAutoAddNoSigningEqualsExpected(t *testing.T) {
 	commitTitle := "feat(test): :smile: this is my title"
 	commitBody := "this is just the body\njust for testing"
-	res, err := utils.BuildGitCommitCommandStr(false, false, commitTitle, commitBody)
+	res, err := utils.BuildGitCommitCommandStr(false, false, true, commitTitle, commitBody)
 	assert.NoError(t, err)
-	expected := fmt.Sprintf("git commit -m %s -m %s", commitTitle, commitBody)
+	expected := fmt.Sprintf("git commit -s -m '%s' -m '%s'", commitTitle, commitBody)
 	assert.Equal(t, expected, res)
 }
 
 func TestBuildGitCommitCommandStrAutoAddNoSigningEqualsExpected(t *testing.T) {
 	commitTitle := "feat(test): :smile: this is my title"
 	commitBody := "this is just the body\njust for testing"
-	res, err := utils.BuildGitCommitCommandStr(true, false, commitTitle, commitBody)
+	res, err := utils.BuildGitCommitCommandStr(true, false, true, commitTitle, commitBody)
 	assert.NoError(t, err)
-	expected := fmt.Sprintf("git commit -a -m %s -m %s", commitTitle, commitBody)
+	expected := fmt.Sprintf("git commit -a -s -m '%s' -m '%s'", commitTitle, commitBody)
 	assert.Equal(t, expected, res)
 }
 
 func TestBuildGitCommitCommandStrNoAutoAddSigningEqualsExpected(t *testing.T) {
 	commitTitle := "feat(test): :smile: this is my title"
 	commitBody := "this is just the body\njust for testing"
-	res, err := utils.BuildGitCommitCommandStr(false, true, commitTitle, commitBody)
+	res, err := utils.BuildGitCommitCommandStr(false, true, true, commitTitle, commitBody)
 	assert.NoError(t, err)
-	expected := fmt.Sprintf("git commit -S -m %s -m %s", commitTitle, commitBody)
+	expected := fmt.Sprintf("git commit -s -S -m '%s' -m '%s'", commitTitle, commitBody)
 	assert.Equal(t, expected, res)
 }
 
 func TestBuildGitCommitCommandStrAutoAddSigningEqualsExpected(t *testing.T) {
 	commitTitle := "feat(test): :smile: this is my title"
 	commitBody := "this is just the body\njust for testing"
-	res, err := utils.BuildGitCommitCommandStr(true, true, commitTitle, commitBody)
+	res, err := utils.BuildGitCommitCommandStr(true, true, true, commitTitle, commitBody)
 	assert.NoError(t, err)
-	expected := fmt.Sprintf("git commit -a -S -m %s -m %s", commitTitle, commitBody)
+	expected := fmt.Sprintf("git commit -a -s -S -m '%s' -m '%s'", commitTitle, commitBody)
 	assert.Equal(t, expected, res)
 }


### PR DESCRIPTION
# Description

Close #137 

- feat: :sparkles: #137  possible to add a commit signature
- ci: :construction_worker: update some ci stuff

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
